### PR TITLE
Input focus on Android + minor bug fixes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
 
     <!-- Material/iOS stylesheets. Will be replaced on deploy -->
     <link rel="stylesheet" href="lib/framework7/css/framework7.min.css">
-    <link rel="stylesheet" href="css/ios-overrides.css">
+    <link rel="stylesheet" href="css/material-overrides.css">
 
     <!-- General stylesheets -->
     <link rel="stylesheet" href="css/font-awesome.min.css">

--- a/www/js/event.js
+++ b/www/js/event.js
@@ -43,16 +43,6 @@ function initEventPage(eventData) {
     }
   }
 
-  if (app.device.android) {
-    window.addEventListener('native.keyboardshow', function() {
-      if ($$('.modal.modal-in').length) return;
-
-      eventContent.animate({
-        scrollTop: $$('.event-signup-btn').offset().top + 100
-      }, 350);
-    });
-  }
-
   function generateAdditionalData(eventData) {
     // Fix start and end date
     var dateString = generateDateString(eventData);

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -14,7 +14,18 @@ var app = new Framework7({
   statusbar: {
     enabled: false,
   },
+  input: {
 
+    /*
+     * This function has finally been added to F7, but it works pretty bad on some
+     * of our pages (like login). Therefore, this global setting must be disabled.
+     *
+     * F7 auto scrolling canm still be enabled on individual inputs. Just run:
+     *   `app.input.scrollIntoView(inputEl, duration, centered, force)`
+     * on the focus event for a specified input.
+     */
+    scrollIntoViewOnFocus: false
+  }
 
   /*statusbarOverlay: false,*/
 });

--- a/www/js/reset_password.js
+++ b/www/js/reset_password.js
@@ -1,10 +1,17 @@
-$$(document).on('page:init', '.page[data-name="reset-password"]', function (page) {
-  // Enable button if the input field isn't empty 
-  $('#reset-password-form input').on('input', function(e) {
-    var resetPwBtn = $('.reset-password-btn');
-    var resetPwFormData = app.form.convertToData('#reset-password-form');
+$$(document).on('page:init', '.page[data-name="reset-password"]', function (pageEvent) {
+  const page = pageEvent.detail;
+  const head = $(page.el).find('.page-content');
 
-    if (resetPwFormData.email != '') {
+  const resetPwBtn = head.find('.reset-password-btn');
+  const form = head.find('#reset-password-form');
+  const formInput = form.find('input');
+  const footer = head.find('.reset-password-footer');
+
+  // Enable button if the input field isn't empty 
+  formInput.on('input', function() {
+    const resetPwFormData = app.form.convertToData(form);
+
+    if (resetPwFormData.email !== '') {
       if (resetPwBtn.hasClass('disabled')) {
         resetPwBtn.removeClass('disabled');
       }
@@ -17,8 +24,8 @@ $$(document).on('page:init', '.page[data-name="reset-password"]', function (page
    * Get the input data from the form and pass it in the auth request. If it fails we add errors,
    * otherwise we load the confirmation page with the input data as context to be displayed
    */
-  $('.reset-password-btn').on('click', function() {
-    var resetPwFormData = app.form.convertToData('#reset-password-form');
+  resetPwBtn.on('click', function() {
+    const resetPwFormData = app.form.convertToData(form);
     
     $.auth.requestPasswordReset(resetPwFormData)
       .done(function() {
@@ -26,20 +33,25 @@ $$(document).on('page:init', '.page[data-name="reset-password"]', function (page
           context: resetPwFormData
         });
       })
-      .fail(function(resp) {
-        var error = 'Ogiltig e-postaddress';
-        var inputEl = $('#reset-password-form input');
-        handleInputError(inputEl, error); // Defined in signup.js
+      .fail(function() {
+        const error = 'Ogiltig e-postaddress';
+        handleInputError(formInput, error); // Defined in signup.js
       });
   });
 
-  $(page.container).on('focus', 'input', function(e) {
-    $('.reset-password-footer').fadeOut();
+  head.on('focus', 'input', function() {
+    footer.fadeOut();
+
+    // Scroll the input to the center on Android
+    if (app.device.android) {
+      const scrollPos = resetPwBtn.offset().top + resetPwBtn.height();
+      head.animate({scrollTop: scrollPos}, 250);
+    }
   });
 
-  $(page.container).on('blur', 'input', function(e) {
+  head.on('blur', 'input', function() {
     setTimeout(function() {
-      $('.reset-password-footer').fadeIn();
+      footer.fadeIn();
     }, 250);
   });
 });

--- a/www/js/signup.js
+++ b/www/js/signup.js
@@ -1,12 +1,19 @@
-$$(document).on('page:init', '.page[data-name="signup"]', function (page) {
-  $('#signup-form input').on('input', function(e) {
-    var inputFilled = true;
-    var signupBtn = $('.signup-btn');
-    var signupFormData = app.form.convertToData('#signup-form');
+$$(document).on('page:init', '.page[data-name="signup"]', function (pageEvent) {
+  const page = pageEvent.detail;
+  const head = $(page.el).find('.page-content');
+
+  const form = head.find('#signup-form');
+  const formInput = form.find('input');
+  const signupBtn = head.find('.signup-btn');
+  const footer = head.find('.signup-footer');
+
+  formInput.on('input', function() {
+    let inputFilled = true;
+    const signupFormData = app.form.convertToData(form);
 
     // Check if all fields a filled in
-    for (var key in signupFormData) {
-      if (signupFormData[key] == '') {
+    for (const key in signupFormData) {
+      if (signupFormData[key] === '') {
         inputFilled = false;
         break;
       }
@@ -26,8 +33,8 @@ $$(document).on('page:init', '.page[data-name="signup"]', function (page) {
    * Get the input data from the form and pass it in the auth request. If it fails we add errors,
    * otherwise we load the confirmation page with the input data as context to be displayed
    */
-  $('.signup-btn').on('click', function() {
-    var signupFormData = app.form.convertToData('#signup-form');
+  signupBtn.on('click', function() {
+    const signupFormData = app.form.convertToData(form);
 
     $.auth.emailSignUp(signupFormData)
       .done(function() {
@@ -36,24 +43,20 @@ $$(document).on('page:init', '.page[data-name="signup"]', function (page) {
         });
       })
       .fail(function(resp) {
-        $('#signup-form input').each(function() {
-          var error = resp.data.errors[this.name];
-          handleInputError(this, error);
+        formInput.each(function() {
+          let error = resp.data.errors[this.name];
+          handleInputError(this, error, form);
         });
       });
   });
 
-  var head = $(page.container);
-  var form = head.find('#signup-form');
-  var footer = head.find('.signup-footer');
-
-  head.on('focus', 'input', function(e) {
+  head.on('focus', 'input', function() {
     footer.fadeOut();
 
     // Animated scroll for android
     if (app.device.android) {
-      var scrollMargin = 65 * (form.find('input').index(this) - 1);
-      form.find('ul').animate({scrollTop: scrollMargin}, 250);
+      const scrollMargin = 65 * (formInput.index(this) - 1);
+      head.animate({scrollTop: scrollMargin}, 250);
     }
   });
 
@@ -71,10 +74,9 @@ $$(document).on('page:init', '.page[data-name="signup"]', function (page) {
  * Add the error class (becomes red) and error message below the 
  * input field if there is an error otherwise remove it
  */
-function handleInputError(inputEl, error) {
-  console.log(error);
-  var item = $(inputEl).parents('.item-content');
-  if (error != null) {
+function handleInputError(inputEl, error, form) {
+  const item = $(inputEl).parents('.item-content');
+  if (error) {
     if (!item.hasClass('error')) {
       item.addClass('error');
       item.after(
@@ -86,9 +88,9 @@ function handleInputError(inputEl, error) {
       item.next()[0].innerText = '* ' + error; //updating error message
     }
 
-    if (inputEl.name == 'password' || inputEl.name == 'password_confirmation') {
-      $('#signup-form input[name="password"]').val('');
-      $('#signup-form input[name="password_confirmation"]').val('');
+    if (inputEl.name === 'password' || inputEl.name === 'password_confirmation') {
+      form.find('input[name="password"]').val('');
+      form.find('input[name="password_confirmation"]').val('');
     }
   } else if (item.hasClass('error')) {
     item.removeClass('error');


### PR DESCRIPTION
* Fixes scroll to custom group field on event page (Android)
* Makes the footer fading work on the login, signup and password reset screen again
* Makes the scroll/input focus (Android) work on the signup page again
* Clean up of `signup.js` and `reset_password.js`
  - Fixes a lot of eslint errors/warnings
  - Removes all the inline jquery selectors. These should be decleared in the init functions for performance.