### PR TITLE
Fixed Fredrik's rookie mistake of removing stage in BASE_URL.

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -35,7 +35,7 @@ var app = new Framework7({
 var $$ = Dom7;
 
 // API URLS
-const BASE_URL = 'https://fsektionen.se';
+const BASE_URL = 'https://stage.fsektionen.se';
 const API = BASE_URL + '/api';
 const AC_URL = 'wss://stage.fsektionen.se/cable';
 


### PR DESCRIPTION
Changed the BASE_URL back to https://stage.fsektionen.se which by mistake was set to https://fsektionen.se in the last merged pull request.