### PR TITLE
Add event timeline with introduction events

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -197,7 +197,7 @@
                     </a>
                   </div>
                   <div class="row">
-                    <a href="#" class="col-33 open-matrix-pb">
+                    <a href="/matrix/" class="col-50 open-matrix-pb">
                       <div class="nollning-btn-matrix"></div>
                     </a>
                     <a href="https://www.fsektionen.se/anonym" target="_blank" class="col-33 external">
@@ -988,9 +988,52 @@
             </div>
           </div>
         </div>
-
       </script>
+
+    <script type="text/template7" id="matrixWeekTemplate">
+      {{#if week}}
+        <div class="timeline-week-container" id="timeline-container-week-{{week}}">
+          <div class="block-title">Vecka {{week}}</div>
+          <div class="timeline timeline-sides" id="timeline-list-week-{{week}}"></div>
+        </div>
+      {{/if}}
+    </script>
+
+    <script type="text/template7" id="matrixEventTemplate">
+      <div class="timeline-item timeline-item-{{side}}">
+        {{#if date}}
+          <div class="timeline-item-date">{{date.getDate()}} <small>{{date.getMonthName()}}</small></div>
+        {{else}}
+          <div class="timeline-item-date"></div>
+        {{/if}}
+        <div class="timeline-item-divider {{event.progress}}"></div>
+        <div class="timeline-item-content">
+          <a href="event/{{event.id}}/" class="timeline-event-container">
+            <div class="timeline-item-time">{{event.time}}</div>
+            <div class="timeline-item-title">{{event.title}}</div>
+            {{#if event.location}}
+              <div class="timeline-item-location">
+                <i class="fa fa-map-marker" aria-hidden="true"></i>
+                {{event.location}}
+              </div>
+            {{/if}}
+            {{#if event.has_signup}}
+              <p class="signup" id="timeline-signup">
+                {{#if event.signup_not_opened_yet}}
+                  <i class="fa fa-user" aria-hidden="true"></i>
+                  Öppnar {{event.event_signup.opens.timeDateString()}}
+                {{else}}
+                  <i class="fa {{event.registered_status_icon}}" aria-hidden="true"></i>
+                  {{event.registered_status}}
+                {{/if}}
+              </p>
+            {{/if}}
+          </a>
+        </div>
+      </div>
+    </script>
     </section>
+
 
 
   <!-- External JS Libraries -->
@@ -1031,6 +1074,7 @@
   <script type="text/javascript" src="js/album.js"></script>
   <script type="text/javascript" src="js/adventures.js"></script>
   <script type="text/javascript" src="js/nollning.js"></script>
+  <script type="text/javascript" src="js/matrix.js"></script>
 </body>
 
 </html>

--- a/www/js/date.js
+++ b/www/js/date.js
@@ -64,6 +64,11 @@ Date.prototype.getDayMonthName = function() {
   return dayNames[this.getDay()] + ', ' + this.getDate() + ' ' + monthNamesShort[this.getMonth()].toLowerCase();
 };
 
+// Get the short name of the month in upper cases
+Date.prototype.getMonthName = function() {
+  return monthNamesShort[this.getMonth()].toUpperCase();
+};
+
 // Get time for dots in events
 Date.prototype.timeWithoutDot = function() {
   return this.getFullHours() + ', ' + this.getDate() + ' ' + monthNames[this.getMonth()].toLowerCase();

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -149,6 +149,25 @@ var nollningView = app.views.create('#view-nollning', {
         },
       ]
     },
+    {
+      name: 'matrix',
+      path: '/matrix/',
+      url: './matrix.html',
+      routes: [
+        {
+          name: 'event',
+          path: '/event/:eventId',
+          url: './event.html',
+          routes: [
+            {
+              name: 'contact',
+              path: 'contact/:contactId',
+              url: './contact.html',
+            },
+          ]
+        }
+      ]
+    },
   ]
 });
 

--- a/www/js/matrix.js
+++ b/www/js/matrix.js
@@ -1,0 +1,189 @@
+let nbrIntroductionWeeks;
+const weekColors = ['#4ab6f4', '#da2550', '#61192f', '#2c370e', '#eb7125'];
+
+$$(document).on('page:init', '.page[data-name="matrix"]', function (e) {
+  const page = $(e.target);
+
+  $.getJSON(API + '/events/matrix')
+    .done(function(resp) {
+      initMatrix(resp);
+      page.find('.matrix-preloader').remove();
+    })
+    .fail(function(resp) {
+      page.find('.matrix-preloader').remove();
+      weekList = $$('#week-list');
+      weekList.append('<div class="timeline-fail"> Kunde inte läsa in nollning :(</div>');
+    });
+});
+
+function initMatrix(resp) {
+  if (typeof resp.error === 'undefined') {
+    initTimeline(resp);
+    setBackgroundGradient();
+    setTimeout(scrollToToday, 100);
+  } else {
+    // No introduction exists
+    error = resp.error;
+    weekList = $$('#week-list');
+    weekList.append('<div class="timeline-fail"> ' + error + '</div>');
+  }
+}
+
+function initTimeline(data) {
+  let weekList = $$('#week-list');
+  let week = 0;
+  let lastDay = null;
+  const fadeInTime = 600;
+
+  // Data is filled with events grouped by week
+  if (data.length !== 0) {
+    // Loop over each week
+    Object.keys(data).forEach(function(key) {
+      // New timeline for each week
+      matrixWeekHTML = app.templates.matrixWeekTemplate({week: week.toString()});
+      $(matrixWeekHTML).hide().appendTo(weekList).fadeIn(fadeInTime);
+
+      let weekEvents = data[key];
+      let side = 'left';
+      let timelineList = $('#timeline-list-week-' + week);
+
+      for (i = 0; i < weekEvents.length; i++) {
+        let event = weekEvents[i];
+
+        setRegisteredStatus(event);
+        setEventProgress(event);
+
+        // Modify time if single or double dot
+        event.start = new Date(event.start);
+        event.time = event.start.hhmm();
+        if (event.dot === 'single') {
+          event.time += ' (.)';
+        } else if (event.dot === 'double') {
+          event.time += ' (..)';
+        }
+
+        // Add date and switch side of timeline if new day
+        if (lastDay !== event.start.getDate()) {
+          if (side === 'right') {
+            side = 'left';
+          } else {
+            side = 'right';
+          }
+          matrixEventHTML = app.templates.matrixEventTemplate({date: event.start, side: side, event: event});
+        } else {
+          matrixEventHTML = app.templates.matrixEventTemplate({side: side, event: event});
+        }
+        $(matrixEventHTML).hide().appendTo(timelineList).fadeIn(fadeInTime);
+        lastDay = event.start.getDate();
+      }
+      week += 1;
+    });
+    setLastEvent();
+  }
+  nbrIntroductionWeeks = week;
+}
+
+function setLastEvent() {
+  // Finds the last event and sets correct divider class
+  date = new Date();
+  day = date.getDate();
+  today = day + ' ' + date.getMonthName();
+
+  // Find the last event
+  data = $$('.timeline-item-divider.today-past');
+  if (data.length === 0) {
+    data = $$('.timeline-item-divider.past');
+    if (data.length === 0) {
+      // Current date before introduction
+      return;
+    }
+  }
+  last = data[data.length - 1];
+
+  // Compare the date of the last event with current date
+  let parent = last.parentElement;
+  if (day > 9) {
+    eventDate = parent.innerText.slice(0, 6);
+  } else {
+    eventDate = parent.innterText.slice(0, 5);
+  }
+  if (today === eventDate) {
+    last.outerHTML = '<div class="timeline-item-divider today-last"></div>';
+  } else {
+    last.outerHTML = '<div class="timeline-item-divider last"></div>';
+  }
+}
+
+function setEventProgress(event) {
+  // Returns if event has already occured, if it is the next
+  // event or if it is further in the future
+  date = new Date();
+  today = date.yyyymmdd();
+  now = today + ' ' + date.hhmm();
+
+  // Day and time of current and previous event
+  eventDate = new Date(event.start);
+  eventDay = eventDate.yyyymmdd();
+  eventTime = eventDate.yyyymmdd() + ' ' + eventDate.hhmm();
+
+  // Check if event is occuring today
+  if (eventDay === today) {
+    progress = 'today-';
+  } else {
+    progress = '';
+  }
+
+  // Check if event is in the past or in the future
+  if (eventTime < now) {
+    progress += 'past';
+  } else {
+    progress += 'future';
+  }
+  event.progress = progress;
+}
+
+function scrollToToday() {
+  // Find today's first event
+  date = $$('.timeline-item-divider.today-past');
+  if (date.length === 0) {
+    date = $$('.timeline-item-divider.today-last');
+    if (date.length === 0) {
+      date = $$('.timeline-item-divider.today-future');
+      if (date.length === 0) {
+        // No event today, look for event in future
+        date = $$('.timeline-item-divider.future');
+        if (date.length === 0) {
+          // Current date is after introduction
+          return;
+        }
+      }
+    }
+  }
+  today = date[0];
+  offset = $$('.navbar').height(); // Compensate for navbar
+  today.style.top = '-' + offset*1.2 + 'px';
+  today.scrollIntoView({behavior: 'smooth', block: 'start'});
+  today.style.top = '0px';
+}
+
+function setBackgroundGradient() {
+  // Calculates the height of each week in percentage of the whole page and
+  // then sets a background gradient with the weekly colors using this information
+  // weekColors should have the same length as the number of introduction weeks
+  if (nbrIntroductionWeeks > 0 && nbrIntroductionWeeks === weekColors.length) {
+    navBarHeight = $$('.navbar').height();
+    contentHeight = $$('#week-list').height();
+    pageHeight = contentHeight + navBarHeight;
+    weekHeight = new Array(nbrIntroductionWeeks);
+    background = 'linear-gradient(180deg, ' + weekColors[0] + ' 0%';
+    for (let week = 0; week < nbrIntroductionWeeks - 1; week++) {
+      height = $$('#timeline-container-week-' + week).height();
+      weekHeight[week] = 100.0 * (height / contentHeight);
+      background += ', ' + weekColors[week + 1] + ' ' + weekHeight.reduce((a, b) => a + b, 0) + '%';
+    }
+    background += ')';
+    document.styleSheets[1].insertRule('.matrix-content::after { background: ' + background + '; height: ' + pageHeight + 'px; }', 0);
+    document.styleSheets[0].cssRules[0].style.background = background;
+    document.styleSheets[0].cssRules[0].style.height = height;
+  }
+}

--- a/www/js/nollning.js
+++ b/www/js/nollning.js
@@ -14,20 +14,7 @@ $$(document).on('page:init', '.page[data-name="nollning"]', function (e) {
     }
   }
 
-  // Setup the photo browser with the matrix
-  var matrixPhotoBrowser = app.photoBrowser.create({
-    photos: ['img/nollning_matrix.png'],
-    swipeToClose: false,
-    toolbar: false,
-    iconsColor: 'white'
-  });
-
-  // Open photo browser on click
-  tab.find('.open-matrix-pb').on('click', function () {
-    matrixPhotoBrowser.open();
-  });
-
-  // Toggle the nollning-toolbar class so the toolbar changes color in the nollning tab
+  // Toggle the nollning-toolbar class so the toolbar changes color in the nollnings tab
   var toolbar = $('.toolbar');
   tab.on('tab:show', function() {
     if (!$('.nollning-content').hasClass('loaded')) setGroupNotification();

--- a/www/matrix.html
+++ b/www/matrix.html
@@ -1,0 +1,19 @@
+<div data-name="matrix" class="page no-toolbar">
+  <div class="navbar" id="timeline-navbar">
+    <div class="navbar-inner sliding">
+      <div class="left">
+        <a href="#" class="back link">
+          <i class="icon icon-back" id="timeline-back"></i>
+          <span class="ios-only">Tillbaka</span>
+        </a>
+      </div>
+      <div class="title" id="timeline-title">Tidslinje</div>
+    </div>
+  </div>
+  <div class="page-content matrix-content">
+    <div class="block matrix-preloader text-align-center">
+      <div class="preloader"></div>
+    </div>
+    <div class="matrix-timeline" id="week-list"></div>
+  </div>
+</div>

--- a/www/scss/index.scss
+++ b/www/scss/index.scss
@@ -20,3 +20,4 @@
 @import 'partials/album';
 @import 'partials/nollning';
 @import 'partials/adventures';
+@import 'partials/matrix';

--- a/www/scss/partials/_contact.scss
+++ b/www/scss/partials/_contact.scss
@@ -23,7 +23,7 @@
 }
 
 .page-content.contact-content {
-  background: $gray;
+  background: $lightgray;
 }
 
 .contact-text textarea {

--- a/www/scss/partials/_matrix.scss
+++ b/www/scss/partials/_matrix.scss
@@ -1,0 +1,145 @@
+.matrix-content {
+  background: $white;
+}
+
+.matrix-content::after {
+  content: '';
+  left: 0;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+#timeline-back {
+  filter: brightness(0) invert(1);
+}
+
+.page-content .timeline {
+  margin: 0;
+  background: $white;
+}
+
+.timeline-fail {
+  color: $black;
+  font-size: 16px;
+  margin: 16px;
+}
+
+#week-list {
+  margin-top: 16px;
+
+  .block-title {
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 16px;
+    margin-left: 16px;
+    overflow: visible;
+    font-size: 18px;
+    color: $black;
+    background: $white;
+    z-index: 2;
+  }
+}
+
+.page-content .timeline-sides .timeline-item {
+  .timeline-item-date {
+    background: transparent;
+    color: $black;
+    z-index: 2;
+  }
+
+  .timeline-item-divider {
+    z-index: 2;
+  }
+}
+
+// EVENT CARDS
+.page-content .timeline-sides .timeline-item .timeline-item-content {
+  background: $black;
+  border-radius: 7px;
+  color: $white;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 12px;
+  word-break: break-all;
+
+  a {
+    display: block;
+    margin-bottom: 12px;
+  }
+
+  .timeline-item-time {
+    color: $white;
+  }
+
+  .timeline-item-title {
+    color: $white;
+    font-size: 14px;
+    font-weight: bold;
+    word-break: break-word;
+  }
+
+  .timeline-item-location {
+    color: $white;
+
+    .fa-map-marker {
+      padding-left: 1px;
+      padding-right: 3px;
+    }
+  }
+}
+
+.page-content .timeline-sides .timeline-item:last-child {
+  padding-bottom: 16px;
+}
+
+#timeline-signup {
+  color: $white;
+  margin: 0;
+}
+
+.signup .fa-user {
+  padding-right: 2px;
+}
+
+// TIMELINE COLORS
+.today-past,
+.past {
+  background: $green;
+
+  &::before {
+    background: $green;
+  }
+
+  &::after {
+    background: $green;
+  }
+}
+
+.today-future,
+.future {
+  background: $gray;
+
+  &::before {
+    background: $gray;
+  }
+
+  &::after {
+    background: $gray;
+  }
+}
+
+.today-last,
+.last {
+  background: $green;
+
+  &::before {
+    background: $green;
+  }
+
+  &::after {
+    background: $gray;
+  }
+}

--- a/www/scss/partials/_variables.scss
+++ b/www/scss/partials/_variables.scss
@@ -2,7 +2,10 @@
 $fsek-orange: #eb7125;
 $white: #ffffff;
 $active-link: #d35400;
-$gray: #f3f3f3;
+$lightgray: #f3f3f3;
+$green: #2e8b57;
+$gray: #bbb;
+$black: #000000;
 
 // Nollning
 $nollning-ground: #590d02;


### PR DESCRIPTION
This PR replaces the introduction matrix image in the introduction tab with a timeline with the introduction events. For this to work, PR "[Add API endpoint for introduction matrix](https://github.com/fsek/web/pull/953)" is needed. These two PR:s together closes #190.

Some information about this PR:
- Each introduction week has its own [F7 vertical timeline](https://framework7.io/docs/timeline.html), meaning that the events are grouped by week
- Events occurring on the same day are grouped to one side of the timeline. When an event occurring on a new day is found, it is placed on the opposite side of the timeline
- The title, location and the user's registration status are shown for each event
- The background color of the event containers changes depending on which week it belongs to and how far into that week the event is (thanks Fredrik for helping me with the CSS!)
- When the events have been loaded and the background gradient has been set, the user is automatically scrolled down to today's date
- The timeline itself is green if the event is in the past or if it is happening right now and light gray otherwise
