### PR TITLE
Support for info groups

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -804,7 +804,7 @@
           {{#group}}
             <li {{#js_compare "this.group_user.unread_count > 0"}} class="unread"{{/js_compare}}
                 data-unread="{{group_user.unread_count}}">
-              <a href="messages/{{id}}/{{name}}" class="item-link item-content">
+              <a href="messages/{{id}}/{{group_type}}/{{name}}" class="item-link item-content">
                 <div class="item-inner">
                   <div class="item-title-row">
                     <div class="item-title">{{name}}</div>

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -137,7 +137,7 @@ var nollningView = app.views.create('#view-nollning', {
       routes: [
         {
           name: 'messages',
-          path: 'messages/:groupId/:groupName',
+          path: 'messages/:groupId/:groupType/:groupName',
           url: './messages.html',
           routes: [
             {
@@ -157,7 +157,7 @@ var groupsView = app.views.create('#view-groups', {
   routesAdd: [
     {
       name: 'messages',
-      path: '/messages/:groupId/:groupName',
+      path: '/messages/:groupId/:groupType/:groupName',
       url: './messages.html',
       routes: [
         {

--- a/www/js/messages.js
+++ b/www/js/messages.js
@@ -65,13 +65,27 @@ function initMessages(head, query) {
 
   // Set group name
   $('#messages-group-name').html(query.groupName);
-  app.navbar.size($('#view-groups .navbar'));
+  app.navbar.size($('#view-nollning .navbar'));
 
-  // Initialize Framework7 message bar
-  const msgBar = app.messagebar.create({
-    el: '.messagebar',
-    maxHeight: 75
-  });
+  // Check if group type is 'info', then we don't want to display messagebar
+  if (query.groupType !== 'info') {
+    // Initialize Framework7 message bar
+    const msgBar = app.messagebar.create({
+      el: '.messagebar',
+      maxHeight: 75
+    });
+
+    // Handle the "send" button. Don't close the keyboard on press
+    const messageBtn = head.find('#messageBtn');
+    nonFocusingButton(messageBtn, function() {
+      groupApp.sendMessage(msgBar.getValue());
+      msgBar.clear();
+    });
+  } else {
+    const msgBar = $('.messagebar');
+    msgBar.addClass('disabled');
+    msgBar.find('textarea')[0].placeholder = 'Chatten är skrivskyddad';
+  }
 
   // Infinite scroll
   const infiniteScroll = head.find('.infinite-scroll-content');
@@ -80,13 +94,6 @@ function initMessages(head, query) {
     app.infiniteScroll.destroy('.infinite-scroll-content');
     infiniteScroll.find('.infinite-scroll-preloader').remove();
   }
-
-  // Handle the "send" button. Don't close the keyboard on press
-  const messageBtn = head.find('#messageBtn');
-  nonFocusingButton(messageBtn, function() {
-    groupApp.sendMessage(msgBar.getValue());
-    msgBar.clear();
-  });
 
   // Functions for batch loading of messages
   function batchPrepare(msgs) {


### PR DESCRIPTION
- Passes `group_type` through to the messages via the href
- The type is checked in `messages.js` and if it's `info` we disable the input field and the send button as well as displaying a message stating read-only