### PR TITLE
Open dialog when entering an album if user is unauthorized to view it

### DIFF
--- a/www/js/album.js
+++ b/www/js/album.js
@@ -5,7 +5,24 @@ $$(document).on('page:init', '.page[data-name="album"]', function (e) {
       initAlbums(resp.album);
     })
     .fail(function(resp) {
-      console.log(resp.statusText);
+      $$('.album-content .preloader').remove();
+      if (resp.statusText === 'Unauthorized') {
+        app.dialog.create({
+          title: 'Fel',
+          text: 'Du är inte auktoriserad för att se albumet. Detta beror på att ditt medlemskap inte är bekräftat. Frågor gällande din medlemsstatus kan skickas till spindelman@fsektionen.se.',
+          closeByBackdropClick: false,
+          buttons: [
+            {
+              text: 'Ok',
+              onClick: function() {
+                alternativesView.router.back();
+              }
+            }
+          ],
+        }).open();
+      } else {
+        $$('.album-content').append('<div class="block">Kunde inte läsa in album</div>');
+      }
     });
 });
 

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -303,6 +303,11 @@ function onBackKey() {
     app.tab.show('#view-home');
   } else if (pageName === 'user-page') {
     backButton();
+  } else if (pageName === 'album') {
+    if (app.dialog.get() !== 'undefined') {
+      app.dialog.close();
+    }
+    router.back();
   } else {
     router.back();
   }


### PR DESCRIPTION
Instead of only showing an infinite preloader, users that are not authorized to view the albums will after this PR get a popup dialog saying exactly that when trying to view one. Closes, #182.