### PR TITLE
Fix for a bug with the backbutton on Android 9+

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -69,6 +69,6 @@
         <variable name="SENDER_ID" value="509736475453" />
     </plugin>
     <plugin name="cordova-plugin-statusbar" spec="^2.4.3" />
-    <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />
+    <plugin name="cordova-plugin-splashscreen" spec="https://github.com/prageeth/cordova-plugin-splashscreen.git#05d8f9a" source="git" />
     <plugin name="cordova-plugin-headercolor" spec="^1.0.0" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cordova-android": "^8.0.0",
     "cordova-ios": "^4.5.4",
     "cordova-plugin-headercolor": "^1.0.0",
-    "cordova-plugin-splashscreen": "^4.0.3",
+    "cordova-plugin-splashscreen": "git+https://github.com/prageeth/cordova-plugin-splashscreen.git#05d8f9a",
     "cordova-plugin-statusbar": "^2.4.3",
     "cordova-plugin-whitelist": "~1.3.2",
     "phonegap-plugin-push": "~2.1.3"

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -245,8 +245,8 @@ function onBackKey() {
   } else if (pageName === 'home') {
     const activeSub = page.find('.subtab.tab-active').attr('id');
 
-    if (activeSub !== 'subtab1') {
-      app.tab.show('#subtab1');
+    if (activeSub !== 'subtab-news') {
+      app.tab.show('#subtab-news');
     } else {
       navigator.app.exitApp();
     }


### PR DESCRIPTION
En bugg med cordova-splash-screen gör att för mobiler med Android 9+ (SDK 28) fungerar inte eventlistener för backbutton och gör att appen exittar direkt.

Efter test verkar det som att Phonegap Build tar direkt från git eller npm även fast vi har en lokal version av pluginen i repon.  Därför måste vi ändra så att config.xml (och package.json) pekar på en korrekt git repo. Det finns en fork av pluginen som har denna fixen. Därför är den smartaste workarounded att använda den tills dess att Apache orkar lägga tid på att fixa sin skit igen.

PR:n inkluderar även en fix för att exitta appen när den är på nyhets-tabben.

Se även:
https://github.com/apache/cordova-plugin-splashscreen/issues/186
https://github.com/apache/cordova-plugin-splashscreen/pull/225